### PR TITLE
[FEATURE] Add navigation feature to browse to next or previous document

### DIFF
--- a/Configuration/Flexforms/Navigation.xml
+++ b/Configuration/Flexforms/Navigation.xml
@@ -72,8 +72,16 @@
                                         <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.rotation</numIndex>
                                         <numIndex index="1">rotation</numIndex>
                                     </numIndex>
+                                    <numIndex index="11">
+                                        <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.volumeBack</numIndex>
+                                        <numIndex index="1">volumeBack</numIndex>
+                                    </numIndex>
+                                    <numIndex index="12">
+                                        <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.volumeForward</numIndex>
+                                        <numIndex index="1">volumeForward</numIndex>
+                                    </numIndex>
                                 </items>
-                                <default>doublepage,pageFirst,pageBack,pageStepBack,pageselect,pageForward,pageStepForward,pageLast,listview,zoom,rotation</default>
+                                <default>doublepage,pageFirst,pageBack,pageStepBack,pageselect,pageForward,pageStepForward,pageLast,listview,zoom,rotation,volumeBack,volumeForward</default>
                                 <minitems>1</minitems>
                             </config>
                         </TCEforms>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -293,6 +293,14 @@
 				<source><![CDATA[Rotate Right]]></source>
 				<target><![CDATA[Ansicht nach rechts drehen]]></target>
 			</trans-unit>
+			<trans-unit id="navigation.volumeBack" approved="yes">
+				<source><![CDATA[Previous document]]></source>
+				<target><![CDATA[Vorheriges Dokument]]></target>
+			</trans-unit>
+			<trans-unit id="navigation.volumeForward" approved="yes">
+				<source><![CDATA[Next document]]></source>
+				<target><![CDATA[Nächstes Dokument]]></target>
+			</trans-unit>
 			<trans-unit id="search.dateFrom" approved="yes">
 				<source><![CDATA[From]]></source>
 				<target><![CDATA[Von]]></target>

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -293,6 +293,14 @@
 				<source><![CDATA[Buttons for rotate image left, right and reset]]></source>
 				<target><![CDATA[Rotations-Buttons: links, rechts und zurück]]></target>
 			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.volumeBack" approved="yes">
+				<source><![CDATA[Show previous volume]]></source>
+				<target><![CDATA[Ein Dokument zurück]]></target>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.volumeForward" approved="yes">
+				<source><![CDATA[Show next volume]]></source>
+				<target><![CDATA[Ein Dokument vor]]></target>
+			</trans-unit>
 			<trans-unit id="plugins.navigation.flexform.features.zoom" approved="yes">
 				<source><![CDATA[Buttons for zoom-in, zoom-out and full screen]]></source>
 				<target><![CDATA[Zoom-Buttons und Vollbild-Modus]]></target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -170,6 +170,12 @@
 			<trans-unit id="rotateRight">
 				<source><![CDATA[Rotate Right]]></source>
 			</trans-unit>
+			<trans-unit id="navigation.volumeBack">
+				<source><![CDATA[Previous document]]></source>
+			</trans-unit>
+			<trans-unit id="navigation.volumeForward">
+				<source><![CDATA[Next document]]></source>
+			</trans-unit>
 			<trans-unit id="selectPage">
 				<source><![CDATA[Page]]></source>
 			</trans-unit>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -194,6 +194,12 @@
 			<trans-unit id="plugins.navigation.flexform.features.rotation">
 				<source><![CDATA[Buttons for rotate image left, right and reset]]></source>
 			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.volumeBack">
+				<source><![CDATA[Show previous document]]></source>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.volumeForward">
+				<source><![CDATA[Show next document]]></source>
+			</trans-unit>
 			<trans-unit id="plugins.navigation.flexform.features.zoom">
 				<source><![CDATA[Buttons for zoom-in, zoom-out and full screen]]></source>
 			</trans-unit>

--- a/Resources/Private/Templates/Navigation/Main.html
+++ b/Resources/Private/Templates/Navigation/Main.html
@@ -236,4 +236,38 @@
         </a>
     </div>
 </f:section>
+
+<f:section name="render.volumeBack">
+    <div class="tx-dlf-navigation-volumeBack">
+        <f:if condition="{volumeBack}">
+            <f:then>
+                <f:link.action addQueryString="1" addQueryStringMethod="GET" additionalParams="{'tx_dlf[page]':'1', 'tx_dlf[id]': '{volumeBack}'}" title="{f:translate(key: 'navigation.volumeBack')}">
+                    <f:translate key="navigation.volumeBack"/>
+                </f:link.action>
+            </f:then>
+            <f:else>
+                <span title="{f:translate(key: 'navigation.volumeBack')}">
+                    <f:translate key="navigation.volumeBack"/>
+                </span>
+            </f:else>
+        </f:if>
+    </div>
+</f:section>
+
+<f:section name="render.volumeForward">
+    <div class="tx-dlf-navigation-volumeForward">
+        <f:if condition="{volumeForward}">
+            <f:then>
+                <f:link.action addQueryString="1" addQueryStringMethod="GET" additionalParams="{'tx_dlf[page]':'1', 'tx_dlf[id]': '{volumeForward}'}" title="{f:translate(key: 'navigation.volumeForward')}">
+                    <f:translate key="navigation.volumeForward"/>
+                </f:link.action>
+            </f:then>
+            <f:else>
+                <span title="{f:translate(key: 'navigation.volumeForward')}">
+                    <f:translate key="navigation.volumeForward"/>
+                </span>
+            </f:else>
+        </f:if>
+    </div>
+</f:section>
 </html>


### PR DESCRIPTION
Hallo Chris,

in diesem PR wurde der NavigationController angepasst, dass er aus der Datenbank die uid's vom vorherigen und nächsten Dokument bezieht. Das vorherige und nächste Dokument ermittelt er per volume_sorting Wert.

Flexform und Sprachdatei fürs Backend ist entsprechend angepasst. Sprachdatei fürs Frontend und Template ebenfalls. Wobei das Template hier eigentlich keine Rolle spielt - habs nur zwecks Vollständigkeit hinzugefügt.

Der angekündigte zweite Merge-Request für das Template-Override und die Icons folgt gleich.

VG,
Michael