### PR TITLE
Fix metadata templates

### DIFF
--- a/Resources/Private/Partials/Metadata/Entries.html
+++ b/Resources/Private/Partials/Metadata/Entries.html
@@ -32,24 +32,22 @@
                 <f:if condition="{kitodo:isArray(subject: '{value}')}">
                     <f:then>
                         <kitodo:stdWrap wrap="{metadataWrap.value}" data="{metaSectionCObj}">
-                            <ul class="subproperties">
-                                <f:for each="{value}" key="key" iteration="subiterator" as="val">
-                                    <f:for each="{configObject.format.0.subentries}" as="subentry">
-                                        <f:if condition="{subentry.indexName} === {key}">
-                                            <f:variable name="subConfigObject">{subentry}</f:variable>
-                                            {subConfigObject.wrap -> kitodo:metadataWrapVariable(name: 'subMetadataWrap')}
-                                            <kitodo:stdWrap wrap="{subMetadataWrap.all}" data="{metaSectionCObj}">
-                                                <kitodo:stdWrap wrap="{subMetadataWrap.key}" data="{metaSectionCObj}">{subConfigObject.label}</kitodo:stdWrap>
-                                                <f:for each="{val}" as="subvalue">
-                                                    <kitodo:stdWrap wrap="{subMetadataWrap.value}" data="{metaSectionCObj}">
-                                                        {subvalue}
-                                                    </kitodo:stdWrap>
-                                                </f:for>
-                                            </kitodo:stdWrap>
-                                        </f:if>
-                                    </f:for>
+                            <f:for each="{value}" key="key" iteration="subiterator" as="val">
+                                <f:for each="{configObject.format.0.subentries}" as="subentry">
+                                    <f:if condition="{subentry.indexName} === {key}">
+                                        <f:variable name="subConfigObject">{subentry}</f:variable>
+                                        {subConfigObject.wrap -> kitodo:metadataWrapVariable(name: 'subMetadataWrap')}
+                                        <kitodo:stdWrap wrap="{subMetadataWrap.all}" data="{metaSectionCObj}">
+                                            <kitodo:stdWrap wrap="{subMetadataWrap.key}" data="{metaSectionCObj}">{subConfigObject.label}</kitodo:stdWrap>
+                                            <f:for each="{val}" as="subvalue">
+                                                <kitodo:stdWrap wrap="{subMetadataWrap.value}" data="{metaSectionCObj}">
+                                                    {subvalue}
+                                                </kitodo:stdWrap>
+                                            </f:for>
+                                        </kitodo:stdWrap>
+                                    </f:if>
                                 </f:for>
-                            </ul>
+                            </f:for>
                         </kitodo:stdWrap>
                     </f:then>
                     <f:else>


### PR DESCRIPTION
This removes the hard-coded `<ul class="subproperties">...</ul>` wrap from the metadata template. All wrapping can be configured via TypoScript anyway.