### PR TITLE
[FEATURE] Include facets from all associated metadata sections for fulltext pages

### DIFF
--- a/Classes/Common/Indexer.php
+++ b/Classes/Common/Indexer.php
@@ -407,15 +407,9 @@ class Indexer
 
             $solrDoc->setField('fulltext', $fullText);
             if (is_array($doc->metadataArray[$doc->toplevelId])) {
-                self::addFaceting($doc, $solrDoc);
+                self::addFaceting($doc, $solrDoc, $physicalUnit);
             }
-            // Add collection information to physical sub-elements if applicable.
-            if (
-                in_array('collection', self::$fields['facets'])
-                && !empty($doc->metadataArray[$doc->toplevelId]['collection'])
-            ) {
-                $solrDoc->setField('collection_faceting', $doc->metadataArray[$doc->toplevelId]['collection']);
-            }
+
             try {
                 $updateQuery->addDocument($solrDoc);
                 self::$solr->service->update($updateQuery);
@@ -502,26 +496,56 @@ class Indexer
      *
      * @param AbstractDocument $doc
      * @param DocumentInterface &$solrDoc
+     * @param array $physicalUnit Array of the physical unit to process
      *
      * @return void
      */
-    private static function addFaceting($doc, &$solrDoc): void
+    private static function addFaceting($doc, &$solrDoc, $physicalUnit): void
     {
-        foreach ($doc->metadataArray[$doc->toplevelId] as $indexName => $data) {
-            if (
-                !empty($data)
-                && substr($indexName, -8) !== '_sorting'
-            ) {
-
-                if (in_array($indexName, self::$fields['facets'])) {
-                    // Remove appended "valueURI" from authors' names for indexing.
-                    if ($indexName == 'author') {
-                        $data = self::removeAppendsFromAuthor($data);
+        // this variable holds all possible facet-values for the index names
+        $facets = [];
+        // use the structlink information
+        foreach ($doc->smLinks['l2p'] as $logicalId => $physicalId) {
+            // find page in structlink
+            if (in_array($physicalUnit['id'], $physicalId)) {
+                // for each associated metadata of structlink
+                foreach ($doc->metadataArray[$logicalId] as $indexName => $data) {
+                    if (
+                        !empty($data)
+                        && substr($indexName, -8) !== '_sorting'
+                    ) {
+                        if (in_array($indexName, self::$fields['facets'])) {
+                            // Remove appended "valueURI" from authors' names for indexing.
+                            if ($indexName == 'author') {
+                                $data = self::removeAppendsFromAuthor($data);
+                            }
+                            // Add facets to facet-array and flatten the values
+                            if (is_array($data)) {
+                                foreach ($data as $value) {
+                                    if (!empty($value)) {
+                                        $facets[$indexName][] = $value;
+                                    }
+                                }
+                            } else {
+                                $facets[$indexName][] = $data;
+                            }
+                        }
                     }
-                    // Add facets to index.
-                    $solrDoc->setField($indexName . '_faceting', $data);
                 }
             }
+        }
+
+        // write all facet values of associated metadata to the page (self & ancestors)
+        foreach ($facets as $indexName => $data) {
+            if (
+                !empty($data)
+            ) {
+                $solrDoc->setField($indexName . '_faceting', $data);
+            }
+        }
+
+        // add sorting information
+        foreach ($doc->metadataArray[$doc->toplevelId] as $indexName => $data) {
             // Add sorting information to physical sub-elements if applicable.
             if (
                 !empty($data)


### PR DESCRIPTION
Hallo Chris,

mir ist wohl in den vergangenen Wochen, vllt. auch durch meine Krankheit, ein PR durchgerutscht, den wir auch für die Adressbücher benötigen und der bereits in Kitodo.Presentation im Main-Branch integriert wurde. Das heißt, wir müssen den hier zukünftig auch nicht irgendwie weiter tracken oder so: https://github.com/kitodo/kitodo-presentation/pull/1441 

Dabei geht es darum, dass der Indexer alle Facetten von übergeordneten Strukturelementen in die physische Seite schreibt, damit man in Volltextsuchen vollumfänglich facettieren kann. Da hier bereits andere PRs im Main-Branch vorangingen, habe ich deshalb hier einen eigenen PR verfasst, damit wir die nicht irgendwie mitberücksichtigen müssen. In sich ist dieser unabhängig von denen.

Könntest Du bitte den PR mergen und in das Livesystem übertragen? Wenn das passiert ist, bitte einmal eine Rückmeldung an mich, damit die Indexierung nochmal testen kann. Wenn etwas gewaltig schiefgegangen ist (wovon ich eigentlich nicht ausgehe), dann müssten wir den doch nochmal zurückrollen...

Danke und viele Grüße,
Michael