### PR TITLE
[OPTIMIZATION] Speed up pagegrid generation

### DIFF
--- a/Classes/Common/AbstractDocument.php
+++ b/Classes/Common/AbstractDocument.php
@@ -321,6 +321,21 @@ abstract class AbstractDocument
     abstract public function getFileLocation(string $id): string;
 
     /**
+     * This gets the location of a file representing a physical page or track
+     *
+     * @access public
+     *
+     * @abstract
+     *
+     * @param string $id The "@ID" attribute of the file node (METS) or the "@id" property of the IIIF resource
+     *
+     * @param string $fileGrp The "@USE" attribute of the file node (METS)
+     *
+     * @return string The file's location as URL
+     */
+    abstract public function getFileLocationInFilegroup(string $id, string $fileGrp): string;
+
+    /**
      * This gets the MIME type of a file representing a physical page or track
      *
      * @access public

--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -246,6 +246,23 @@ final class MetsDocument extends AbstractDocument
     }
 
     /**
+     * @see AbstractDocument::getFileLocationInFilegroup()
+     */
+    public function getFileLocationInFilegroup(string $id, string $fileGrp): string
+    {
+        $location = $this->mets->xpath('./mets:fileSec/mets:fileGrp[@USE="' . $fileGrp . '"]/mets:file[@ID="' . $id . '"]/mets:FLocat[@LOCTYPE="URL"]');
+        if (
+            !empty($id)
+            && !empty($location)
+        ) {
+            return (string) $location[0]->attributes('http://www.w3.org/1999/xlink')->href;
+        } else {
+            $this->logger->warning('There is no file node with @ID "' . $id . '"');
+            return '';
+        }
+    }
+
+    /**
      * @see AbstractDocument::getFileMimeType()
      */
     public function getFileMimeType(string $id): string

--- a/Classes/Controller/PageGridController.php
+++ b/Classes/Controller/PageGridController.php
@@ -106,7 +106,7 @@ class PageGridController extends AbstractController
             if (array_intersect($fileGrpsThumb, array_keys($this->document->getCurrentDocument()->physicalStructureInfo[$this->document->getCurrentDocument()->physicalStructure[$number]]['files'])) !== []) {
                 while ($fileGrpThumb = array_shift($fileGrpsThumb)) {
                     if (!empty($this->document->getCurrentDocument()->physicalStructureInfo[$this->document->getCurrentDocument()->physicalStructure[$number]]['files'][$fileGrpThumb])) {
-                        $entry['thumbnail'] = $this->document->getCurrentDocument()->getFileLocation($this->document->getCurrentDocument()->physicalStructureInfo[$this->document->getCurrentDocument()->physicalStructure[$number]]['files'][$fileGrpThumb]);
+                        $entry['thumbnail'] = $this->document->getCurrentDocument()->getFileLocationInFilegroup($this->document->getCurrentDocument()->physicalStructureInfo[$this->document->getCurrentDocument()->physicalStructure[$number]]['files'][$fileGrpThumb], $fileGrpThumb);
                         break;
                     }
                 }


### PR DESCRIPTION
Hallo Chris,

habe auch im Main für diese Optimierung einen PR erstellt...für unser Kitodo.Presentation ist das hier etwas angepasst, weil Beatricze im Main bereits andere Variablennamen und Co. verwendet.

Könntest Du das bitte zeitnah einspielen?

Im Kern wird beim Pagegrid nicht mehr die Funktion GetFileLocation genutzt, sondern eine angepasste, bei der man die FileGroup mitbestimmt. Dadurch werden nicht mehr alle unsere 7 Filegroups durchgegangen, sondern nur noch eine spezifische ... in dem Fall dann "THUMBS". Pagegrid kommt damit nicht mehr ins Timeout und insgesamt ist es (in unserem Fall) ca. 600% schneller beim initialen Aufbau.

Danke und viele Grüße,
Michael