### PR TITLE
[BUGFIX] Fix search in document filtering and highlighting

### DIFF
--- a/Classes/Common/Solr/SolrSearch.php
+++ b/Classes/Common/Solr/SolrSearch.php
@@ -537,7 +537,7 @@ class SolrSearch implements \Countable, \Iterator, \ArrayAccess, QueryResultInte
                                 $searchResult['highlight'] = $doc['highlight'];
                                 $searchResult['highlight_word'] = preg_replace('/^;|;$/', '',       // remove ; at beginning or end
                                                                   preg_replace('/;+/', ';',         // replace any multiple of ; with a single ;
-                                                                  preg_replace('/[{~\d*}{\s+}{^=*\d+.*\d*}`~!@#$%\^&*()_|+-=?;:\'",.<>\{\}\[\]\\\]/', ';', $this->searchParams['query']))); // replace search operators and special characters with ;
+                                                                  preg_replace('/[{~\d*}{\s+}{^=*\d+.*\d*}{\sAND\s}{\sOR\s}{\sNOT\s}`~!@#$%\^&*()_|+-=?;:\'",.<>\{\}\[\]\\\]/', ';', $this->searchParams['query']))); // replace search operators and special characters with ;
                             }
                             $documents[$doc['uid']]['searchResults'][] = $searchResult;
                         }

--- a/Classes/Domain/Repository/DocumentRepository.php
+++ b/Classes/Domain/Repository/DocumentRepository.php
@@ -683,7 +683,10 @@ class DocumentRepository extends Repository
                 return $prevDocument['uid'];
             }
             
-            return $this->getLastChild($this->getPreviousDocumentUid($parentId));
+            $previousDocumentId = $this->getPreviousDocumentUid($parentId);
+            if ($previousDocumentId) {
+                return $this->getLastChild($previousDocumentId);
+            }
         }
     }
 
@@ -727,7 +730,10 @@ class DocumentRepository extends Repository
                 return $nextDocument['uid'];
             }
             
-            return $this->getFirstChild($this->getNextDocumentUid($parentId));
+            $nextDocumentId = $this->getNextDocumentUid($parentId);
+            if ($nextDocumentId) {
+                return $this->getFirstChild($nextDocumentId);
+            }
         }
     }
 

--- a/Classes/Middleware/SearchInDocument.php
+++ b/Classes/Middleware/SearchInDocument.php
@@ -104,7 +104,9 @@ class SearchInDocument implements MiddlewareInterface
                     [
                         'tx_dlf[id]' => !empty($resultDocument->getUid()) ? $resultDocument->getUid() : $parameters['uid'],
                         'tx_dlf[page]' => $resultDocument->getPage(),
-                        'tx_dlf[highlight_word]' => $parameters['q']
+                        'tx_dlf[highlight_word]' => preg_replace('/^;|;$/', '',       // remove ; at beginning or end
+                                                    preg_replace('/;+/', ';',         // replace any multiple of ; with a single ;
+                                                    preg_replace('/[{~\d*}{\s+}{^=*\d+.*\d*}{\sAND\s}{\sOR\s}{\sNOT\s}`~!@#$%\^&*()_|+-=?;:\'",.<>\{\}\[\]\\\]/', ';', $parameters['q']))) // replace search operators and special characters with ;
                     ]
                 );
 

--- a/Resources/Public/JavaScript/PageView/SearchInDocument.js
+++ b/Resources/Public/JavaScript/PageView/SearchInDocument.js
@@ -212,7 +212,7 @@ function triggerSearchAfterHitLoad() {
 
         if(searchedQueryParam && decodeURIComponent(queryParam[0]).indexOf(searchedQueryParam) !== -1) {
             $("input[id='tx-dlf-search-in-document-query']").val(decodeURIComponent(queryParam[1]));
-            $("#tx-dlf-search-in-document-form").submit();
+            //$("#tx-dlf-search-in-document-form").submit();
             break;
         }
     }


### PR DESCRIPTION
Hallo Chris,

dies ist ein PR für das DLF-Package, der die Beschwerden über Fehler beim Highlighting beheben soll. Suche im Dokument filterte suchoperatoren nicht wirklich raus und die normale Suche hat "and, or, not" nicht weggefiltert und dann stellenweise beim highlighten freigedreht. Außerdem macht die Suche im Dokument ein "Auto-Submit" der Suche beim Blättern, was zu highlighten aller tokens auf der Seite führt und das Highlighting effektiv beim Blättern kaputt macht. Blubbert aktuell alles wegen der Adressbücher so doof hoch, letzteres auch nur ein Hotfix.

Außerdem behebe ich eine Macke im DocumentRepository (eigentlich ein Bugfix von Thomas Low), wo es einen Fehler in der Rekursion gab. Führt dazu, dass wir in der Summe ca. 800-1000ms umsonst herumgerechnet haben obwohl man vorzeitig hätte abbrechen können.

Kannst Du das bitte zeitnah einspielen und mir Bescheid geben?

Danke und viele Grüße,
Michael